### PR TITLE
Nissix plugin scope-packages on yoshi-monorepo

### DIFF
--- a/test/projects/kitchensink-javascript/package.json
+++ b/test/projects/kitchensink-javascript/package.json
@@ -33,7 +33,9 @@
   },
   "yoshi": {
     "projectType": "app",
-    "externalUnprocessedModules": ["untranspiled-dependency"],
+    "externalUnprocessedModules": [
+      "untranspiled-dependency"
+    ],
     "entry": {
       "app": "./client",
       "other": "./other"

--- a/test/projects/kitchensink-typescript/package.json
+++ b/test/projects/kitchensink-typescript/package.json
@@ -41,7 +41,9 @@
   },
   "yoshi": {
     "projectType": "app",
-    "externalUnprocessedModules": ["untranspiled-dependency"],
+    "externalUnprocessedModules": [
+      "untranspiled-dependency"
+    ],
     "entry": {
       "app": "./client",
       "other": "./other"


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 5.84s



Output Log:
Migrating package "yoshi-monorepo" in .


## Migration from non scope to @wix/scoped packages
> /tmp/fd9eec967fbe2812e3999fa7c20a01bb

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
test/projects/kitchensink-javascript/package.json
test/projects/kitchensink-typescript/package.json
```

